### PR TITLE
Add getItem method

### DIFF
--- a/jrspinner/src/main/java/jrizani/jrspinner/JRSpinner.java
+++ b/jrspinner/src/main/java/jrizani/jrspinner/JRSpinner.java
@@ -140,6 +140,18 @@ public class JRSpinner extends android.support.v7.widget.AppCompatEditText {
         this.items = items;
         postInvalidate();
     }
+    
+    /**
+     * method to get an item from the set items list
+     *
+     * @param position of the desired item
+     */
+    public String getItem(int position) {
+        if (position > -1 && position < items.length){
+            return items[position];
+        }
+        throw new ArrayIndexOutOfBoundsException("Position does not exists on array.");
+    }
 
     /**
      * method to set the title of spinner dialog


### PR DESCRIPTION
When querying data from a database directly to the spinner, sometimes is needed to access the selected item.
To avoid another query to the database just to get the list again, we can access the position item directly from the spinner.